### PR TITLE
enable multiple prok configurations in package.json

### DIFF
--- a/bin/prok
+++ b/bin/prok
@@ -20,9 +20,10 @@ var Prok = require('..');
 var program = new Command('prok')
   .version(pkg.version)
   .usage('[options] [procfile]')
+  .option('-c, --config <config>', 'specify a configuration', false)
   .option('-e, --env <file>', 'specify an environment configuration file', false)
-  .option('-p, --procfile <file>', 'specify an Procfile', false)
-  .option('-r, --root <dir>', 'specify an Procfile', false)
+  .option('-p, --procfile <file>', 'specify a Procfile', false)
+  .option('-r, --root <dir>', 'specify a root directory', false)
   .parse(process.argv);
 
 /**
@@ -43,15 +44,17 @@ var processes;
  */
 
 var procfile = program.procfile || program.args[0] || join(cwd, 'Procfile');
+var config = program.procfile || program.args[0];
 
 /**
  * Load the processes
  */
 
 if (exists(procfile)) {
-  prok.procfile(procfile)
+  prok.procfile(procfile);
 } else if (processes = json(join(cwd, 'package.json')).processes) {
-  prok.processes(processes);
+  if (!config && typeof processes.default !== 'object') prok.processes(processes);
+  else prok.processes(processes[config || 'default']);
 } else {
   console.error('  \033[31mError:\033[m cannot find Procfile or "processes" field in your package.json');
   program.outputHelp();

--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
     "url": "git://github.com/LapwingLabs/prok.git"
   },
   "dependencies": {
-    "commander": "^2.5.0",
-    "component-emitter": "^1.1.3",
-    "debug": "^2.2.0",
+    "commander": "2.8.1",
+    "component-emitter": "1.2.0",
+    "debug": "2.2.0",
     "extend.js": "0.0.2",
     "parse-procfile": "0.0.2",
-    "ps-tree": "0.0.3",
-    "split": "^0.3.2"
+    "ps-tree": "1.0.1",
+    "split": "1.0.0"
   },
   "devDependencies": {
     "mocha": "*",

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 var Prok = require('..');
 
 var prok = Prok(__dirname)
-  .processes(require('./package.json').processes)
+  .processes(require('./package.json').processes[process.argv[2] || 'default'])
   .env(__dirname + '/.env');
 
 prok.start();

--- a/test/package.json
+++ b/test/package.json
@@ -2,9 +2,15 @@
   "name": "prok",
   "version": "0.0.1",
   "processes": {
-    "web": "node app-1.js",
-    "web2": "node app-2.js",
-    "web3": "node app-3.js",
-    "mongod": "mongod --dbpath db"
+    "default": {
+      "web": "node app-1.js",
+      "web2": "node app-2.js",
+      "web3": "node app-3.js",
+      "mongod": "mongod --dbpath db"
+    },
+    "test": {
+      "web1": "node app-1.js",
+      "mongod": "mongod --dbpath db"
+    }
   }
 }


### PR DESCRIPTION
so we can launch independent test or worker configurations that have external dependencies without requiring the base app to be running.
